### PR TITLE
Synchronous factories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Unionized 
+# Unionized
 
 A user-friendly factory system for easily building up complex objects. Entirely asynchronous.
 Recommended for use in testing, but you never know where else this could be useful!
@@ -123,6 +123,28 @@ lateNightPickupFactory.create(function(err, result) { console.log(result); });
 //          endAt: '12am',
 //        },
 //        name: 'San Francisco Ferry Building'
+//     }
+//   }
+
+
+```If using `.json()`, you can optionally define and instantiate factories
+synchronously.
+
+```javascript
+var pickupFactory = unionized.define(function() {
+  this.set('pickupWindow.startAt', '11pm');
+  this.set('pickupWindow.endAt', '12am');
+});
+result = lateNightPickupFactory.json();
+console.log(result);
+
+// prints:
+//   {
+//      pickup: {
+//        pickupWindow: {
+//          startAt: '11pm',
+//          endAt: '12am'
+//        }
 //     }
 //   }
 ```

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "factory",
     "objects"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "async": "^0.9.0"
+  },
   "devDependencies": {
     "blanket": "~1.1.6",
     "chai": "~1.9.0",

--- a/src/unionized.coffee
+++ b/src/unionized.coffee
@@ -39,7 +39,7 @@ class Unionized
         context = context.parent
       factoryFns
 
-    # if passing a callback, assume all definitions are async
+    # if passing a callback, assume all definitions are asynchronous
     if typeof callback is 'function'
       asyncFactoryFns = factoryFns.map (factoryFn) ->
         (cb) ->
@@ -49,7 +49,7 @@ class Unionized
         return callback err if err?
         callback null, definition._resolve()
 
-    # if not a callback, assume all definitions are not synchronous
+    # if not a callback, assume all definitions are synchronous
     else
       factoryFns.forEach (factoryFn) ->
         factoryFn.call definition, definition.args

--- a/test/inherited_factories.spec.coffee
+++ b/test/inherited_factories.spec.coffee
@@ -3,8 +3,6 @@ fibrous   = require 'fibrous'
 Unionized = require '..'
 
 describe 'inherited factories', ->
-  {parent, child, result} = {}
-
   beforeEach fibrous ->
     parent = Unionized.define fibrous ->
       @set 'foo', 'herp'
@@ -13,10 +11,19 @@ describe 'inherited factories', ->
     child = parent.define fibrous ->
       @set 'bar', 'slurp'
 
-    result = child.sync.create()
+    grandChild = child.define fibrous ->
+      @set 'boom', 'pow'
+
+    @child = child.sync.create()
+    @grandChild = grandChild.sync.create()
 
   it 'borrows default attributes up the inheritance chain', ->
-    expect(result.foo).to.equal 'herp'
+    expect(@child.foo).to.equal 'herp'
 
   it 'can overwrite default attributes', ->
-    expect(result.bar).to.equal 'slurp'
+    expect(@child.bar).to.equal 'slurp'
+
+  it 'can inherit from grandparents', ->
+    expect(@grandChild.boom).to.equal 'pow'
+    expect(@grandChild.bar).to.equal 'slurp'
+    expect(@grandChild.foo).to.equal 'herp'

--- a/test/synchronous_factories.spec.coffee
+++ b/test/synchronous_factories.spec.coffee
@@ -1,0 +1,59 @@
+expect    = require('chai').expect
+fibrous   = require 'fibrous'
+Unionized = require '..'
+
+describe 'a synchronous factory', ->
+  {factory} = {}
+
+  beforeEach ->
+    factory = Unionized.define ->
+      @set 'foo', 10
+      @set 'biz.fizz', 10
+      @set 'biz.faz', 10
+
+  it 'creates an object', fibrous ->
+    result = factory.json
+      'baz': 'bang'
+    expect(result.foo).to.equal 10
+    expect(result.biz).to.deep.equal fizz: 10, faz: 10
+    expect(result.baz).to.equal 'bang'
+
+  # it 'builds an object', fibrous ->
+  #   result = factory.sync.build()
+  #   expect(result.foo).to.equal 10
+  #   expect(result.biz).to.deep.equal fizz: 10, faz: 10
+
+  # it 'JSONs up an object', fibrous ->
+  #   result = factory.sync.json()
+  #   expect(result.foo).to.equal 10
+  #   expect(result.biz).to.deep.equal fizz: 10, faz: 10
+
+  # it 'adds a new property', fibrous ->
+  #   result = factory.sync.create baz: 20
+  #   expect(result.baz).to.equal 20
+  #   expect(result.foo).to.equal 10
+  #   expect(result.biz).to.deep.equal fizz: 10, faz: 10
+
+  # it 'changes a property', fibrous ->
+  #   result = factory.sync.create foo: 20
+  #   expect(result.foo).to.equal 20
+  #   expect(result.biz).to.deep.equal fizz: 10, faz: 10
+
+  # it 'changes a nested property', fibrous ->
+  #   result = factory.sync.create 'biz.faz': 20
+  #   expect(result.foo).to.equal 10
+  #   expect(result.biz).to.deep.equal fizz: 10, faz: 20
+
+  # it 'changes the root of a nested property', fibrous ->
+  #   result = factory.sync.create biz: 20
+  #   expect(result.biz).to.equal 20
+
+  # it 'unsets a property', fibrous ->
+  #   result = factory.sync.create foo: undefined
+  #   expect(Object.keys result).to.not.contain 'foo'
+  #   expect(result.biz).to.deep.equal fizz: 10, faz: 10
+
+  # it 'unsets the root of nested properties', fibrous ->
+  #   result = factory.sync.create biz: undefined
+  #   expect(result.foo).to.equal 10
+  #   expect(Object.keys result).to.not.contain 'biz'

--- a/test/synchronous_factories.spec.coffee
+++ b/test/synchronous_factories.spec.coffee
@@ -7,53 +7,18 @@ describe 'a synchronous factory', ->
 
   beforeEach ->
     factory = Unionized.define ->
-      @set 'foo', 10
-      @set 'biz.fizz', 10
-      @set 'biz.faz', 10
+      @set 'name', 'apple'
 
   it 'creates an object', fibrous ->
     result = factory.json
-      'baz': 'bang'
-    expect(result.foo).to.equal 10
-    expect(result.biz).to.deep.equal fizz: 10, faz: 10
-    expect(result.baz).to.equal 'bang'
+      'type': 'fruit'
+    expect(result.name).to.equal 'apple'
+    expect(result.type).to.equal 'fruit'
 
-  # it 'builds an object', fibrous ->
-  #   result = factory.sync.build()
-  #   expect(result.foo).to.equal 10
-  #   expect(result.biz).to.deep.equal fizz: 10, faz: 10
+  it 'inherits from parents', fibrous ->
+    child = factory.define ->
+      @set 'store', 'Whole Foods'
 
-  # it 'JSONs up an object', fibrous ->
-  #   result = factory.sync.json()
-  #   expect(result.foo).to.equal 10
-  #   expect(result.biz).to.deep.equal fizz: 10, faz: 10
-
-  # it 'adds a new property', fibrous ->
-  #   result = factory.sync.create baz: 20
-  #   expect(result.baz).to.equal 20
-  #   expect(result.foo).to.equal 10
-  #   expect(result.biz).to.deep.equal fizz: 10, faz: 10
-
-  # it 'changes a property', fibrous ->
-  #   result = factory.sync.create foo: 20
-  #   expect(result.foo).to.equal 20
-  #   expect(result.biz).to.deep.equal fizz: 10, faz: 10
-
-  # it 'changes a nested property', fibrous ->
-  #   result = factory.sync.create 'biz.faz': 20
-  #   expect(result.foo).to.equal 10
-  #   expect(result.biz).to.deep.equal fizz: 10, faz: 20
-
-  # it 'changes the root of a nested property', fibrous ->
-  #   result = factory.sync.create biz: 20
-  #   expect(result.biz).to.equal 20
-
-  # it 'unsets a property', fibrous ->
-  #   result = factory.sync.create foo: undefined
-  #   expect(Object.keys result).to.not.contain 'foo'
-  #   expect(result.biz).to.deep.equal fizz: 10, faz: 10
-
-  # it 'unsets the root of nested properties', fibrous ->
-  #   result = factory.sync.create biz: undefined
-  #   expect(result.foo).to.equal 10
-  #   expect(Object.keys result).to.not.contain 'biz'
+    result = child.json()
+    expect(result.store).to.equal 'Whole Foods'
+    expect(result.name).to.equal 'apple'


### PR DESCRIPTION
@demands 

Allows defining and creating factories synchronously or asynchronously.

Basically, if .json() is called without a callback provided, it executes synchonously and assumes that all definitions are synchronous as well.

Additionally, I fixed a bug where factories can only inherit from one parent (not grandparents).