### PR TITLE
Array.isArray should suffice?

### DIFF
--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -15,11 +15,7 @@ module.exports = _ =
     false
 
   isArray: (value) ->
-    value and
-    typeof value is 'object' and
-    typeof value.length is 'number'
-    toString.call(value) is '[object Array]' or
-    false
+    Array.isArray value
 
   last: (array) ->
     array[array.length - 1]


### PR DESCRIPTION
Replace the current implementation (which is almost word for word what the ecmascript 5 spec says) with what seems to be the widely supported `Array.isArray` function.