### PR TITLE
Refactor, fix synchronous interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Unionized
 
-A user-friendly factory system for easily building up complex objects. Entirely asynchronous.
+A user-friendly factory system for easily building up complex objects.
+Can be either synchronous or asynchronous.
 Recommended for use in testing, but you never know where else this could be useful!
 
 [![NPM version](https://badge.fury.io/js/unionized.png)](http://badge.fury.io/js/unionized)
@@ -13,7 +14,6 @@ Recommended for use in testing, but you never know where else this could be usef
 Create complex objects really easily:
 
 ```javascript
-
 var unionized = require('unionized');
 unionized.create({
   'pickup.pickupWindow.startAt': '2pm',
@@ -56,7 +56,7 @@ pickupFactory.create(function(err, result) { console.log(result); });
 //   }
 ```
 
-now we can customize the objects that our factory returns us:
+We can customize the objects that our factory returns us:
 
 ```javascript
 pickupFactory.create({
@@ -78,6 +78,22 @@ pickupFactory.create({
 //      }
 //   }
 ```
+
+
+We can do this **synchronously**, too:
+
+```javascript
+var pickupFactory = unionized.define(function() {
+  this.set('pickup.pickupWindow.startAt', '2pm');
+  this.set('pickup.pickupWindow.endAt', '4pm');
+  this.set('pickup.name', 'San Francisco Ferry Building');
+});
+```
+
+but then we can only use `.json` on the factory to get a POJO; `.create` and `.build` are
+only for asynchronous factories.
+
+
 
 We can also embed factories inside other factories:
 
@@ -128,27 +144,23 @@ lateNightPickupFactory.create(function(err, result) { console.log(result); });
 
 ```
 
-If using `.json()`, you can optionally define and instantiate factories
-synchronously.
 
-```javascript
-var pickupFactory = unionized.define(function() {
-  this.set('pickupWindow.startAt', '11pm');
-  this.set('pickupWindow.endAt', '12am');
-});
-result = lateNightPickupFactory.json();
-console.log(result);
+The main **methods** on a factory are:
+ 
+1. `create`: Use with database models that have a `save` method, this will save a real record to the database.
+  (For async factories only.)
+    
+2. `build`: Also used with database models, but only returns a model, does not save it to the database.
+  (For async factories only.)
 
-// prints:
-//   {
-//      pickup: {
-//        pickupWindow: {
-//          startAt: '11pm',
-//          endAt: '12am'
-//        }
-//     }
-//   }
-```
+3. `json`: Generate a plain ol' object. Sync or async.
+
+
+The **factory function** itself can either take 1 argument (a callback, implies an async interface),
+or 0 arguments, for a sync interface.
+You can pass additional parameters to your factory functions - e.g. `factory.create(attrs, extra1, extra2, callback)` -
+and your factory function can access the extra parameters by introspecting `this.args`.
+
 
 # License
 

--- a/src/factory_definition.coffee
+++ b/src/factory_definition.coffee
@@ -24,7 +24,11 @@ module.exports = class FactoryDefinition
     dotpath.clear @_out, path
 
   embed: (path, factory, callback) ->
+    # [bb] only support async embed, until there's a real use case otherwise.
+    unless typeof callback is 'function' then throw new Error "`embed` requires a callback."
+
     return _.defer(callback) if dotpath.containsSubpath @_attrPaths, path
+
     factory[@mode] (@get(path) ? {}), (err, value) =>
       return callback(err) if err?
       @set path, value
@@ -36,6 +40,9 @@ module.exports = class FactoryDefinition
     _.times count, (index) => @set "#{path}[#{index}]", value[index % value.length]
 
   embedArray: (path, defaultCount, factory, callback) ->
+    # [bb] only support async embed, until there's a real use case otherwise.
+    unless typeof callback is 'function' then throw new Error "`embed` requires a callback."
+
     return _.defer(callback) if dotpath.containsSubpath @_attrPaths, path
     count = @_arraySizes[path] ? defaultCount
     embedInstance = (index, done) =>

--- a/src/helpers.coffee
+++ b/src/helpers.coffee
@@ -24,8 +24,9 @@ module.exports = _ =
   last: (array) ->
     array[array.length - 1]
 
+  ## [bb] ??
   defer: (args..., done) ->
-    throw new TypeError unless _.isFunction done
+    throw new TypeError('`defer` requires a callback') unless _.isFunction done
     args = [null, args...] # callback without an error
     setTimeout (-> done.apply undefined, args), 1
 

--- a/src/unionized.coffee
+++ b/src/unionized.coffee
@@ -60,11 +60,12 @@ class Unionized
       stack = factoryFns.map (factoryFn) ->
         if factoryFn.length is 1   # async
           return (cb) ->
-            factoryFn.call definition, definition.args..., cb
+            # factoryFn can introspect `@args` for special cases.
+            factoryFn.call definition, cb
         else
           return (cb) ->
             try    # sync parent
-              factoryFn.call definition, definition.args
+              factoryFn.call definition
               cb()
             catch err
               cb err

--- a/src/unionized.coffee
+++ b/src/unionized.coffee
@@ -11,49 +11,73 @@ _ = require './helpers'
 FactoryDefinition = require './factory_definition'
 
 class Unionized
+  #
+  # new Unionized(model, factoryFn, parent)
+  # new Unionized(model, factoryFn)
+  # new Unionized(factoryFn, parent)
+  # new Unionized(factoryFn)
+  #
   constructor: (args...) ->
-    @parent = args.pop() if typeof _.last(args) is 'object'
+    if typeof _.last(args) is 'object'
+      @parent = args.pop()
+
     @factoryFn = args.pop()
+
+    # infer from lack of callback that it's meant to be run synchronously.
+    if @factoryFn.length is 0
+      @_synchronous = true
+      if @parent? and not @parent._synchronous
+        throw new Error("Cannot define a synchronous factory as a child of an asynchronous factory")
+
+    else if @factoryFn.length > 1
+      throw new Error "Factory functions should take 1 or 0 arguments."
+
     @model = args.pop()
     @children = []
 
+
   ###
-  Builds a plain, JSON-compatible object from your factory
-
-  @param {string} [name] - Name of the child factory to use
-    (or, just use this one if a name is not supplied)
-  @param {object} [factoryParams] - Parameters to send to the factory function
-
-  @returns {object} A plain old JavaScript object
-  @async
+  Builds a plain, JSON-compatible object from your factory.
+  sync or async.
   ###
   _json: (definition, callback) ->
-    [..., callback] = arguments
+    if @_synchronous and callback?
+      throw new Error "Synchronous factory .json does not accept a callback"
+    else if not @_synchronous and not callback?
+      throw new Error "Asynchronous factory .json requires a callback"
 
     # get factory fns from factory and all relatives
-    factoryFns = do =>
-      factoryFns = if @factoryFn then [@factoryFn] else []
-      context = @
-      while context.parent?
-        factoryFns.unshift(context.parent.factoryFn) if context.parent.factoryFn?
-        context = context.parent
-      factoryFns
+    # TODO refactor this loop?
+    factoryFns = if @factoryFn then [@factoryFn] else []
+    child = @
+    while child.parent?
+      factoryFns.unshift(child.parent.factoryFn) if child.parent.factoryFn?
+      child = child.parent
 
-    # if passing a callback, assume all definitions are asynchronous
-    if typeof callback is 'function'
-      asyncFactoryFns = factoryFns.map (factoryFn) ->
-        (cb) ->
-          factoryFn.call definition, definition.args..., cb
+    # already guarded above that synchronous factory can't have async in its parents,
+    # but vice-versa is ok.
+    if callback?
+      stack = factoryFns.map (factoryFn) ->
+        if factoryFn.length is 1   # async
+          return (cb) ->
+            factoryFn.call definition, definition.args..., cb
+        else
+          return (cb) ->
+            try    # sync parent
+              factoryFn.call definition, definition.args
+              cb()
+            catch err
+              cb err
 
-      async.series asyncFactoryFns, (err) ->
-        return callback err if err?
-        callback null, definition._resolve()
+      async.series stack, (err) ->
+        if err? then callback err
+        else callback null, definition._resolve()
 
-    # if not a callback, assume all definitions are synchronous
-    else
+    else  # all sync
       factoryFns.forEach (factoryFn) ->
         factoryFn.call definition, definition.args
       return definition._resolve()
+
 
   ###
   Creates an instance of the model with the parameters defined when you created
@@ -64,9 +88,12 @@ class Unionized
   @param {object} [factoryParams] - Parameters to send to the factory function
 
   @returns {object} An instance of the factory model
-  @async
+
+  only async!
   ###
   _build: (definition, callback) ->
+    if @_synchronous
+      throw new Error "Cannot call `build` on a synchronous factory."
     @_json definition, (err, result) =>
       return callback err if err?
       model = @modelInstanceWith result
@@ -85,9 +112,12 @@ class Unionized
   @async
   ###
   _create: (definition, callback) ->
+    if @_synchronous
+      throw new Error "Cannot call `create` on a synchronous factory."
     @_build definition, (err, model) =>
       return callback err if err?
       @saveModel model, callback
+
 
   ###
   Define a sub-factory that shares the factory function, model, and overwritten
@@ -99,15 +129,20 @@ class Unionized
   @param {function} factoryFn - Factory function for the child factory. Will be
     applied before the factory function of the parent factory.
 
+  - IMPT: factoryFn should take either a callback (1 arg), or no arguments.
+
   @returns {Unionized} A new factory that descends from the current one.
   ###
-  define: (args...) ->
+  define: (args..., factoryFn) ->
+    if typeof factoryFn isnt 'function'
+      throw new Error "Factory definition needs a factory function"
+
     name =
-      if typeof args[0] is 'string'
-        args.shift()
-      else
-        @children.length
-    @children[name] = new Unionized args..., @
+      if typeof args[0] is 'string' then args.shift()
+      else @children.length
+
+    @children[name] = new Unionized args..., factoryFn, @
+
 
   ###
   Find a descendant factory by name
@@ -121,6 +156,7 @@ class Unionized
   child: (name) ->
     @children[name] or throw "Unknown factory `#{name}`"
 
+
   ###
   Create a new instance of the factory model, given a set of attributes
 
@@ -131,6 +167,7 @@ class Unionized
   modelInstanceWith: (attrs) ->
     if @model?
       new @model attrs
+    # delegate up the tree until there's a model.
     else if @parent?
       @parent.modelInstanceWith(attrs)
     else
@@ -150,17 +187,39 @@ class Unionized
     else
       _.defer model, callback
 
-factoryFunctions = ['json', 'build', 'create']
-for fn in factoryFunctions
-  do (fn) ->
-    fnWithAllArgs = Unionized::["_#{fn}"]
-    Unionized::[fn] = (args...) ->
-      instance = if typeof args[0] is 'string' then @child(args.shift()) else @
-      [..., callback] = arguments
+
+for fnName in ['json', 'build', 'create']
+  do (fnName) ->
+    fnWithAllArgs = Unionized::["_#{fnName}"]
+
+    # any of these are valid:
+    #  fn(name, attrs, callback)
+    #  fn(attrs, callback)
+    #  fn(callback)
+    #  fn(attrs, extra1, extra2, callback)   (see factories_with_arguments.spec)
+    #  fn(attrs, extra1, extra2)
+    #
+    Unionized::[fnName] = (args...) ->
+      if typeof args[0] is 'string'
+        childName = args.shift()
+        instance = @child(childName)
+      else
+        instance = @
+
+      # callback is necessary for async factories. otherwise can be undefined.
+      # (each method has its own handling/requirements for callback.)
+      if typeof _.last(args) is 'function'
+        callback = args.pop()
+
       attrs = args.shift()
-      definition = new FactoryDefinition(attrs, fn, args)
+
+      # any remaining `args` are arbitrary, for introspection in factoryFn.
+      definition = new FactoryDefinition attrs, fnName, args
+
       fnWithAllArgs.call instance, definition, callback
 
-# create two default, async factory functions so that we can create an instance
-# without defining any models
-module.exports = new Unionized()
+
+# create default, (synchronous) factory for extending.
+baseFactory = new Unionized (->)
+
+module.exports = baseFactory

--- a/test/base_factory.spec.coffee
+++ b/test/base_factory.spec.coffee
@@ -3,14 +3,19 @@ Unionized = require '..'
 
 describe 'using the base factory', ->
 
-  it 'creates an empty object', ->
-    result = Unionized.create()
-    expect(result).to.be.defined
+  describe '.json', ->
+    it 'creates an empty object', ->
+      result = Unionized.json
+      expect(result).to.be.ok
 
-  it 'creates an object that contains things', ->
-    result = Unionized.build
-      fish: ['one', 'two', 'red', 'blue']
-      'info.author': 'Theodore Geisel'
+    it 'creates an object that contains things', ->
+      result = Unionized.json
+        fish: ['one', 'two', 'red', 'blue']
+        'info.author': 'Theodore Geisel'
+      expect(result.info.author).to.equal 'Theodore Geisel'
+      expect(result.fish).to.have.length.of 4
 
-    expect(result.info.author).to.equal 'Theodore Geisel'
-    expect(result.fish).to.have.length.of 4
+  describe '.build and .create', ->
+    it 'are not supported (b/c it\'s synchronous)', ->
+      expect(-> Unionized.create(->)).to.throw /create.*synchronous/i
+      expect(-> Unionized.build(->)).to.throw /build.*synchronous/i

--- a/test/base_factory.spec.coffee
+++ b/test/base_factory.spec.coffee
@@ -1,15 +1,14 @@
 expect    = require('chai').expect
-fibrous   = require 'fibrous'
 Unionized = require '..'
 
 describe 'using the base factory', ->
 
-  it 'creates an empty object', fibrous ->
-    result = Unionized.sync.create()
+  it 'creates an empty object', ->
+    result = Unionized.create()
     expect(result).to.be.defined
 
-  it 'creates an object that contains things', fibrous ->
-    result = Unionized.sync.create
+  it 'creates an object that contains things', ->
+    result = Unionized.build
       fish: ['one', 'two', 'red', 'blue']
       'info.author': 'Theodore Geisel'
 

--- a/test/embedded_factories.spec.coffee
+++ b/test/embedded_factories.spec.coffee
@@ -1,6 +1,6 @@
 expect    = require('chai').expect
 _         = require 'lodash'
-Unionized = require '../src/unionized'
+Unionized = require '..'
 async = require 'async'
 
 describe 'embedded factories', ->

--- a/test/embedded_factories.spec.coffee
+++ b/test/embedded_factories.spec.coffee
@@ -16,29 +16,25 @@ describe 'embedded factories', ->
 
   describe 'async', ->
     before ->
-      @simpleFactory = Unionized.define @Model, (callback) ->
+      simpleFactory = Unionized.define @Model, (callback) ->
         @set 'val1', 'hello'
         @set 'val2', 'goodbye'
         callback()
 
       @embeddedFactory = Unionized.define (callback) ->
-        # TODO
-        @embed 'simple1', @simpleFactory, =>
-          @embed 'simple2', @simpleFactory, =>
-            callback()
+        async.series [
+          (cb) => @embed 'simple1', simpleFactory, cb
+          (cb) => @embed 'simple2', simpleFactory, cb
+        ], (err) -> callback err
 
     describe 'model instantiation', ->
-      describe '.create', ->
+      describe '.json', ->
         before (done) ->
-          @embeddedFactory.create (err, @result) => done err
+          @embeddedFactory.json (err, @result) => done err
 
-        it 'returns instances of Model', ->
-          expect(@result.simple1.isAModel).to.be.true
-          expect(@result.simple2.isAModel).to.be.true
-
-        it 'saves returned Models', ->
-          expect(@result.simple1.isSaved).to.be.true
-          expect(@result.simple2.isSaved).to.be.true
+        it 'returns plain-object instances', ->
+          expect(@result.simple1.isAModel).to.be.undefined
+          expect(@result.simple2.isAModel).to.be.undefined
 
       describe '.build', ->
         before (done) ->
@@ -52,13 +48,18 @@ describe 'embedded factories', ->
           expect(@result.simple1.isSaved).to.be.false
           expect(@result.simple2.isSaved).to.be.false
 
-      describe '.json', ->
+      describe '.create', ->
         before (done) ->
-          @embeddedFactory.json (err, @result) => done err
+          @embeddedFactory.create (err, @result) => done err
 
-        it 'returns plain-object instances', ->
-          expect(@result.simple1.isAModel).to.be.undefined
-          expect(@result.simple2.isAModel).to.be.undefined
+        it 'returns instances of Model', ->
+          expect(@result.simple1.isAModel).to.be.true
+          expect(@result.simple2.isAModel).to.be.true
+
+        it 'saves returned Models', ->
+          expect(@result.simple1.isSaved).to.be.true
+          expect(@result.simple2.isSaved).to.be.true
+
 
     describe 'overriding embedded factory values', ->
       it 'can override an entire embedded factory', (done) ->
@@ -75,15 +76,16 @@ describe 'embedded factories', ->
           done()
 
 
-  describe 'sync', ->
+  ### NOT SUPPORTED ###
+  describe.skip 'sync', ->
     before ->
-      @simpleFactory = Unionized.define @Model, ->
+      simpleFactory = Unionized.define @Model, ->
         @set 'val1', 'hello'
         @set 'val2', 'goodbye'
 
       @embeddedFactory = Unionized.define ->
-        @embed 'simple1', @simpleFactory
-        @embed 'simple2', @simpleFactory
+        @embed 'simple1', simpleFactory
+        @embed 'simple2', simpleFactory
 
     describe 'model instantiation', ->
       describe '.json', ->
@@ -103,3 +105,18 @@ describe 'embedded factories', ->
       it 'can override parts of an embedded factory', ->
         @result = @embeddedFactory.json { 'simple1.val1': 'greetings' }
         expect(@result.simple1).to.deep.equal val1: 'greetings', val2: 'goodbye'
+
+
+  describe 'async embedding sync', ->
+    before ->
+      @syncFactory = Unionized.define @Model, ->
+        @set 'val1', 'hello'
+        @set 'val2', 'goodbye'
+
+      @asyncFactory = Unionized.define (callback) ->
+        async.series [
+          (cb) => @embed 'simple1', @syncFactory, cb
+          (cb) => @embed 'simple2', @syncFactory, cb
+        ], (err) -> callback err
+
+    it 'TODO'

--- a/test/embedded_factories.spec.coffee
+++ b/test/embedded_factories.spec.coffee
@@ -1,7 +1,7 @@
 expect    = require('chai').expect
 _         = require 'lodash'
-fibrous   = require 'fibrous'
-Unionized = require '..'
+Unionized = require '../src/unionized'
+async = require 'async'
 
 describe 'embedded factories', ->
   before ->
@@ -22,6 +22,7 @@ describe 'embedded factories', ->
         callback()
 
       @embeddedFactory = Unionized.define (callback) ->
+        # TODO
         @embed 'simple1', @simpleFactory, =>
           @embed 'simple2', @simpleFactory, =>
             callback()
@@ -85,18 +86,6 @@ describe 'embedded factories', ->
         @embed 'simple2', @simpleFactory
 
     describe 'model instantiation', ->
-      describe '.build', ->
-        before ->
-          @result = @embeddedFactory.build()
-
-        it 'returns instances of Model', ->
-          expect(@result.simple1.isAModel).to.be.true
-          expect(@result.simple2.isAModel).to.be.true
-
-        it 'does not save returned Models', ->
-          expect(@result.simple1.isSaved).to.be.false
-          expect(@result.simple2.isSaved).to.be.false
-
       describe '.json', ->
         before ->
           @result = @embeddedFactory.json()

--- a/test/embedded_factories.spec.coffee
+++ b/test/embedded_factories.spec.coffee
@@ -4,10 +4,8 @@ fibrous   = require 'fibrous'
 Unionized = require '..'
 
 describe 'embedded factories', ->
-  {Model, simpleFactory, embeddedFactory} = {}
-
   before ->
-    class Model
+    class @Model
       constructor: (attrs) ->
         _.merge @, attrs
       save: (callback) ->
@@ -16,59 +14,103 @@ describe 'embedded factories', ->
       isAModel: yes
       isSaved: false
 
-    simpleFactory = Unionized.define Model, fibrous ->
-      @set 'val1', 'hello'
-      @set 'val2', 'goodbye'
+  describe 'async', ->
+    before ->
+      @simpleFactory = Unionized.define @Model, (callback) ->
+        @set 'val1', 'hello'
+        @set 'val2', 'goodbye'
+        callback()
 
-    embeddedFactory = Unionized.define fibrous ->
-      @sync.embed 'simple1', simpleFactory
-      @sync.embed 'simple2', simpleFactory
+      @embeddedFactory = Unionized.define (callback) ->
+        @embed 'simple1', @simpleFactory, =>
+          @embed 'simple2', @simpleFactory, =>
+            callback()
 
-  describe 'model instantiation', ->
-    describe '.create', ->
-      {result} = {}
+    describe 'model instantiation', ->
+      describe '.create', ->
+        before (done) ->
+          @embeddedFactory.create (err, @result) => done err
 
-      before fibrous ->
-        result = embeddedFactory.sync.create()
+        it 'returns instances of Model', ->
+          expect(@result.simple1.isAModel).to.be.true
+          expect(@result.simple2.isAModel).to.be.true
 
-      it 'returns instances of Model', ->
-        expect(result.simple1.isAModel).to.be.true
-        expect(result.simple2.isAModel).to.be.true
+        it 'saves returned Models', ->
+          expect(@result.simple1.isSaved).to.be.true
+          expect(@result.simple2.isSaved).to.be.true
 
-      it 'saves returned Models', ->
-        expect(result.simple1.isSaved).to.be.true
-        expect(result.simple2.isSaved).to.be.true
+      describe '.build', ->
+        before (done) ->
+          @embeddedFactory.build (err, @result) => done err
 
-    describe '.build', ->
-      {result} = {}
+        it 'returns instances of Model', ->
+          expect(@result.simple1.isAModel).to.be.true
+          expect(@result.simple2.isAModel).to.be.true
 
-      before fibrous ->
-        result = embeddedFactory.sync.build()
+        it 'does not save returned Models', ->
+          expect(@result.simple1.isSaved).to.be.false
+          expect(@result.simple2.isSaved).to.be.false
 
-      it 'returns instances of Model', ->
-        expect(result.simple1.isAModel).to.be.true
-        expect(result.simple2.isAModel).to.be.true
+      describe '.json', ->
+        before (done) ->
+          @embeddedFactory.json (err, @result) => done err
 
-      it 'does not save returned Models', ->
-        expect(result.simple1.isSaved).to.be.false
-        expect(result.simple2.isSaved).to.be.false
+        it 'returns plain-object instances', ->
+          expect(@result.simple1.isAModel).to.be.undefined
+          expect(@result.simple2.isAModel).to.be.undefined
 
-    describe '.json', ->
-      {result} = {}
+    describe 'overriding embedded factory values', ->
+      it 'can override an entire embedded factory', (done) ->
+        @embeddedFactory.json { 'simple1': 'overridden' }, (err, @result) =>
+          return done err if err
+          expect(@result.simple1).to.equal 'overridden'
+          expect(@result.simple2).to.deep.equal val1: 'hello', val2: 'goodbye'
+          done()
 
-      before fibrous ->
-        result = embeddedFactory.sync.json()
+      it 'can override parts of an embedded factory', (done) ->
+        @embeddedFactory.json { 'simple1.val1': 'greetings' }, (err, @result) =>
+          return done err if err
+          expect(@result.simple1).to.deep.equal val1: 'greetings', val2: 'goodbye'
+          done()
 
-      it 'returns plain-object instances', ->
-        expect(result.simple1.isAModel).to.be.undefined
-        expect(result.simple2.isAModel).to.be.undefined
 
-  describe 'overriding embedded factory values', ->
-    it 'can override an entire embedded factory', fibrous ->
-      result = embeddedFactory.sync.json 'simple1': 'overridden'
-      expect(result.simple1).to.equal 'overridden'
-      expect(result.simple2).to.deep.equal val1: 'hello', val2: 'goodbye'
+  describe 'sync', ->
+    before ->
+      @simpleFactory = Unionized.define @Model, ->
+        @set 'val1', 'hello'
+        @set 'val2', 'goodbye'
 
-    it 'can override parts of an embedded factory', fibrous ->
-      result = embeddedFactory.sync.json 'simple1.val1': 'greetings'
-      expect(result.simple1).to.deep.equal val1: 'greetings', val2: 'goodbye'
+      @embeddedFactory = Unionized.define ->
+        @embed 'simple1', @simpleFactory
+        @embed 'simple2', @simpleFactory
+
+    describe 'model instantiation', ->
+      describe '.build', ->
+        before ->
+          @result = @embeddedFactory.build()
+
+        it 'returns instances of Model', ->
+          expect(@result.simple1.isAModel).to.be.true
+          expect(@result.simple2.isAModel).to.be.true
+
+        it 'does not save returned Models', ->
+          expect(@result.simple1.isSaved).to.be.false
+          expect(@result.simple2.isSaved).to.be.false
+
+      describe '.json', ->
+        before ->
+          @result = @embeddedFactory.json()
+
+        it 'returns plain-object instances', ->
+          expect(@result.simple1.isAModel).to.be.undefined
+          expect(@result.simple2.isAModel).to.be.undefined
+
+    describe 'overriding embedded factory values', ->
+      it 'can override an entire embedded factory', ->
+        @result = @embeddedFactory.json { 'simple1': 'overridden' }
+        expect(@result.simple1).to.equal 'overridden'
+        expect(@result.simple2).to.deep.equal val1: 'hello', val2: 'goodbye'
+
+      it 'can override parts of an embedded factory', ->
+        @result = @embeddedFactory.json { 'simple1.val1': 'greetings' }
+        expect(@result.simple1).to.deep.equal val1: 'greetings', val2: 'goodbye'

--- a/test/factories_with_arguments.spec.coffee
+++ b/test/factories_with_arguments.spec.coffee
@@ -7,15 +7,37 @@ describe 'factories with arguments', ->
 
   describe 'a factory that creates an object whose values are dependent on other values', ->
 
-    beforeEach ->
-      factory = Unionized.define fibrous (foobar) ->
-        @set 'foo.bar', foobar
-        @set 'baz', 10
+    describe 'async', ->
+      beforeEach ->
+        factory = Unionized.define (callback) ->
+          foobar = @args[0]
+          @set 'foo.bar', foobar
+          @set 'baz', 10
+          callback()
 
-    it 'passes arguments into the factory function', fibrous ->
-      result = factory.sync.json({}, 12)
-      expect(result.foo.bar).to.equal 12
+      it 'passes arguments into the factory function', (done) ->
+        factory.json {}, 12, (err, result) ->
+          return done err if err
+          expect(result.foo.bar).to.equal 12
+          done()
 
-    it 'sets the default values properly', fibrous ->
-      result = factory.sync.json({}, 12)
-      expect(result.baz).to.equal 10
+      it 'sets the default values properly', (done) ->
+        factory.json {}, 12, (err, result) ->
+          return done err if err
+          expect(result.baz).to.equal 10
+          done()
+
+    describe 'sync', ->
+      beforeEach ->
+        factory = Unionized.define ->
+          foobar = @args[0]
+          @set 'foo.bar', foobar
+          @set 'baz', 10
+
+      it 'passes arguments into the factory function', ->
+        result = factory.json {}, 12
+        expect(result.foo.bar).to.equal 12
+
+      it 'sets the default values properly', ->
+        result = factory.json {}, 12
+        expect(result.baz).to.equal 10

--- a/test/factories_with_arrays.spec.coffee
+++ b/test/factories_with_arrays.spec.coffee
@@ -37,6 +37,7 @@ describe 'factories with arrays', ->
     describe 'async', ->
       beforeEach ->
         # TODO use callback instead of fibrous
+        # -- doesn't work -- :confused: --
         @factory = Unionized.define fibrous ->
           @sync.embedArray 'wibbles', 5, Unionized.define fibrous ->
             @set 'name', 'bob'

--- a/test/factories_with_arrays.spec.coffee
+++ b/test/factories_with_arrays.spec.coffee
@@ -3,43 +3,68 @@ fibrous   = require 'fibrous'
 Unionized = require '..'
 
 describe 'factories with arrays', ->
-  {factory} = {}
-
   describe 'a factory that defines an array', ->
-    factory = Unionized.define fibrous ->
-      @setArray 'wiseMen', 3, ['melchior', 'balthazar', 'caspar']
+    describe 'async', ->
+      beforeEach ->
+        @factory = Unionized.define (callback) ->
+          @setArray 'wiseMen', 3, ['melchior', 'balthazar', 'caspar']
+          process.nextTick -> callback()
 
-    it 'sets up the default array properly', fibrous ->
-      result = factory.sync.json()
-      expect(result.wiseMen).to.deep.equal ['melchior', 'balthazar', 'caspar']
+      it 'sets up the default array properly', fibrous ->
+        result = @factory.sync.json()
+        expect(result.wiseMen).to.deep.equal ['melchior', 'balthazar', 'caspar']
 
-    it 'allows overridden wiseMen counts', fibrous ->
-      result = factory.sync.json 'wiseMen[]': 5
-      expect(result.wiseMen).to.deep.equal ['melchior', 'balthazar', 'caspar', 'melchior', 'balthazar']
+      it 'allows overridden wiseMen counts', fibrous ->
+        result = @factory.sync.json 'wiseMen[]': 5
+        expect(result.wiseMen).to.deep.equal ['melchior', 'balthazar', 'caspar', 'melchior', 'balthazar']
 
-    it 'allows overridden specific wise men', fibrous ->
-      result = factory.sync.json 'wiseMen[2]': 'jeff'
-      expect(result.wiseMen).to.deep.equal ['melchior', 'balthazar', 'jeff']
+      it 'allows overridden specific wise men', fibrous ->
+        result = @factory.sync.json 'wiseMen[2]': 'jeff'
+        expect(result.wiseMen).to.deep.equal ['melchior', 'balthazar', 'jeff']
+
+    describe 'sync', ->
+      beforeEach ->
+        @factory = Unionized.define ->
+          @setArray 'wiseMen', 3, ['melchior', 'balthazar', 'caspar']
+
+      it 'sets up the default array properly', ->
+        result = @factory.json()
+        expect(result.wiseMen).to.deep.equal ['melchior', 'balthazar', 'caspar']
+
 
   describe 'a factory that defines an embedded array', ->
+    describe 'async', ->
+      beforeEach ->
+        # TODO use callback instead of fibrous
+        @factory = Unionized.define fibrous ->
+          @sync.embedArray 'wibbles', 5, Unionized.define fibrous ->
+            @set 'name', 'bob'
+            @set 'age', 10
 
-    beforeEach ->
-      factory = Unionized.define fibrous ->
-        @sync.embedArray 'wibbles', 5, Unionized.define fibrous ->
-          @set 'name', 'bob'
-          @set 'age', 10
+      it 'sets up the default embedded array properly', fibrous ->
+        result = @factory.sync.json()
+        expect(result.wibbles).to.have.length 5
+        expect(result.wibbles.every((wibble) -> wibble.name is 'bob')).to.be.ok
+        expect(result.wibbles.every((wibble) -> wibble.age is 10)).to.be.ok
 
-    it 'sets up the default embedded array properly', fibrous ->
-      result = factory.sync.json()
-      expect(result.wibbles).to.have.length 5
-      expect(result.wibbles.every((wibble) -> wibble.name is 'bob')).to.be.ok
-      expect(result.wibbles.every((wibble) -> wibble.age is 10)).to.be.ok
+      it 'allows overridden wibble counts', fibrous ->
+        result = @factory.sync.json 'wibbles[]': 2
+        expect(result.wibbles).to.have.length 2
 
-    it 'allows overridden wibble counts', fibrous ->
-      result = factory.sync.json 'wibbles[]': 2
-      expect(result.wibbles).to.have.length 2
+      it 'allows overridden specific wibbles', fibrous ->
+        result = @factory.sync.json 'wibbles[2].name': 'suzanna'
+        expect(result.wibbles[0].name).to.equal 'bob'
+        expect(result.wibbles[2].name).to.equal 'suzanna'
 
-    it 'allows overridden specific wibbles', fibrous ->
-      result = factory.sync.json 'wibbles[2].name': 'suzanna'
-      expect(result.wibbles[0].name).to.equal 'bob'
-      expect(result.wibbles[2].name).to.equal 'suzanna'
+    describe 'sync', ->
+      beforeEach ->
+        @factory = Unionized.define ->
+          @embedArray 'wibbles', 5, Unionized.define ->
+            @set 'name', 'bob'
+            @set 'age', 10
+
+      it 'sets up the default embedded array properly', ->
+        result = @factory.json()
+        expect(result.wibbles).to.have.length 5
+        expect(result.wibbles.every((wibble) -> wibble.name is 'bob')).to.be.ok
+        expect(result.wibbles.every((wibble) -> wibble.age is 10)).to.be.ok

--- a/test/factories_with_arrays.spec.coffee
+++ b/test/factories_with_arrays.spec.coffee
@@ -4,6 +4,7 @@ Unionized = require '..'
 
 describe 'factories with arrays', ->
   describe 'a factory that defines an array', ->
+
     describe 'async', ->
       beforeEach ->
         @factory = Unionized.define (callback) ->
@@ -56,7 +57,8 @@ describe 'factories with arrays', ->
         expect(result.wibbles[0].name).to.equal 'bob'
         expect(result.wibbles[2].name).to.equal 'suzanna'
 
-    describe 'sync', ->
+    ### NOT SUPPORTED ###
+    describe.skip 'sync', ->
       beforeEach ->
         @factory = Unionized.define ->
           @embedArray 'wibbles', 5, Unionized.define ->

--- a/test/factories_with_logic.spec.coffee
+++ b/test/factories_with_logic.spec.coffee
@@ -6,23 +6,52 @@ describe 'factories with logic', ->
   {factory} = {}
 
   describe 'a factory that creates an object whose values are dependent on other values', ->
+    describe 'async', ->
+      beforeEach ->
+        factory = Unionized.define (callback) ->
+          @set 'smaller', 10
+          @set 'larger', @get('smaller') + 10
+          @set 'foo.bar', 12
+          callback()
 
-    beforeEach ->
-      factory = Unionized.define fibrous ->
-        @set 'smaller', 10
-        @set 'larger', @get('smaller') + 10
-        @set 'foo.bar', 12
+      it 'sets the default values properly', (done) ->
+        factory.json (err, result) ->
+          return done err if err
+          expect(result.smaller).to.equal 10
+          expect(result.larger).to.equal 20
+          done()
 
-    it 'sets the default values properly', fibrous ->
-      result = factory.sync.json()
-      expect(result.smaller).to.equal 10
-      expect(result.larger).to.equal 20
+      it 'sets the dependent value based on input', (done) ->
+        factory.json { smaller: 20 }, (err, result) ->
+          return done err if err
+          expect(result.smaller).to.equal 20
+          expect(result.larger).to.equal 30
+          done()
 
-    it 'sets the dependent value based on input', fibrous ->
-      result = factory.sync.json smaller: 20
-      expect(result.smaller).to.equal 20
-      expect(result.larger).to.equal 30
+      it 'overrides the logic value', (done) ->
+        factory.json { larger: 2000 }, (err, result) ->
+          return done err if err
+          expect(result.larger).to.equal 2000
+          done()
 
-    it 'overrides the logic value', fibrous ->
-      result = factory.sync.json larger: 2000
-      expect(result.larger).to.equal 2000
+
+    describe 'sync', ->
+      beforeEach ->
+        factory = Unionized.define ->
+          @set 'smaller', 10
+          @set 'larger', @get('smaller') + 10
+          @set 'foo.bar', 12
+
+      it 'sets the default values properly', ->
+        result = factory.json()
+        expect(result.smaller).to.equal 10
+        expect(result.larger).to.equal 20
+
+      it 'sets the dependent value based on input', ->
+        result = factory.json smaller: 20
+        expect(result.smaller).to.equal 20
+        expect(result.larger).to.equal 30
+
+      it 'overrides the logic value', fibrous ->
+        result = factory.json larger: 2000
+        expect(result.larger).to.equal 2000

--- a/test/global_factories.spec.coffee
+++ b/test/global_factories.spec.coffee
@@ -15,9 +15,5 @@ describe 'the global object', ->
       expect(result.fiz).to.equal 'buzz'
       done()
 
-  it 'cannot use an undefined factory', (done) ->
-    Unionized.sync.create 'unknown', (err, result) ->
-      expect(err).to.be.an.instanceof Error
-      expect(err.message).to.equal 'Unknown factory `unknown`'
-      expect(result).not.to.be.ok
-      done()
+  it 'cannot use an undefined factory', ->
+    expect(-> Unionized.sync.create 'unknown').to.throw 'Unknown factory `unknown`'

--- a/test/global_factories.spec.coffee
+++ b/test/global_factories.spec.coffee
@@ -4,13 +4,20 @@ Unionized = require '..'
 
 describe 'the global object', ->
 
-  it 'can create a global factory', fibrous ->
-    Unionized.define 'known', fibrous ->
+  it 'can create a global factory', ->
+    Unionized.define 'known', (callback) ->
       @set 'fiz', 'buzz'
+      callback()
 
-  it 'can use a global factory', fibrous ->
-    result = Unionized.sync.create('known')
-    expect(result.fiz).to.equal 'buzz'
+  it 'can use a global factory', (done) ->
+    Unionized.create 'known', (err, result) ->
+      return done err if err
+      expect(result.fiz).to.equal 'buzz'
+      done()
 
-  it 'cannot use an undefined factory', fibrous ->
-    expect(-> Unionized.sync.create 'unknown').to.throw 'Unknown factory `unknown`'
+  it 'cannot use an undefined factory', (done) ->
+    Unionized.sync.create 'unknown', (err, result) ->
+      expect(err).to.be.an.instanceof Error
+      expect(err.message).to.equal 'Unknown factory `unknown`'
+      expect(result).not.to.be.ok
+      done()

--- a/test/inherited_factories.spec.coffee
+++ b/test/inherited_factories.spec.coffee
@@ -3,36 +3,103 @@ fibrous   = require 'fibrous'
 Unionized = require '..'
 
 describe 'inherited factories', ->
-  beforeEach fibrous ->
-    parent = Unionized.define fibrous ->
-      @set 'foo', 'herp'
-      @set 'bar', 'derp'
+  describe 'async', ->
+    beforeEach fibrous ->
+      parent = Unionized.define (callback) ->
+        @set 'foo', 'herp'
+        @set 'bar', 'derp'
+        callback()
 
-    child = parent.define fibrous ->
-      @set 'bar', 'slurp'
+      child = parent.define (callback) ->
+        @set 'bar', 'slurp'
+        callback()
 
-    grandChild = child.define fibrous ->
-      @set 'boom', 'pow'
+      grandChild = child.define (callback) ->
+        @set 'boom', 'pow'
+        callback()
 
-    @child = child.sync.create()
-    @grandChild = grandChild.sync.create()
-    @babyGrandChild = grandChild.sync.create(
-      foo: 'baby'
-      boom: 'waaah'
-    )
+      @child = child.sync.create()
+      @grandChild = grandChild.sync.create()
+      @babyGrandChild = grandChild.sync.create(
+        foo: 'baby'
+        boom: 'waaah'
+      )
 
-  it 'borrows default attributes up the inheritance chain', ->
-    expect(@child).to.have.property 'foo', 'herp'
+    it 'borrows default attributes up the inheritance chain', ->
+      expect(@child).to.have.property 'foo', 'herp'
 
-  it 'can overwrite default attributes', ->
-    expect(@child).to.have.property 'bar', 'slurp'
+    it 'can overwrite default attributes', ->
+      expect(@child).to.have.property 'bar', 'slurp'
 
-  it 'can inherit from grandparents', ->
-    expect(@grandChild).to.have.property 'boom', 'pow'
-    expect(@grandChild).to.have.property 'bar', 'slurp'
-    expect(@grandChild).to.have.property 'foo', 'herp'
+    it 'can inherit from grandparents', ->
+      expect(@grandChild).to.have.property 'boom', 'pow'
+      expect(@grandChild).to.have.property 'bar', 'slurp'
+      expect(@grandChild).to.have.property 'foo', 'herp'
 
-  it 'can pass arguments', ->
-    expect(@babyGrandChild).to.have.property 'foo', 'baby'
-    expect(@babyGrandChild).to.have.property 'boom', 'waaah'
-    expect(@babyGrandChild).to.have.property 'bar', 'slurp'
+    it 'can pass arguments', ->
+      expect(@babyGrandChild).to.have.property 'foo', 'baby'
+      expect(@babyGrandChild).to.have.property 'boom', 'waaah'
+      expect(@babyGrandChild).to.have.property 'bar', 'slurp'
+
+
+  describe 'sync', ->
+    beforeEach ->
+      parent = Unionized.define ->
+        @set 'foo', 'herp'
+        @set 'bar', 'derp'
+
+      child = parent.define ->
+        @set 'bar', 'slurp'
+
+      grandChild = child.define ->
+        @set 'boom', 'pow'
+
+      @child = child.build()
+      @grandChild = grandChild.build()
+      @babyGrandChild = grandChild.build(
+        foo: 'baby'
+        boom: 'waaah'
+      )
+
+    it 'borrows default attributes up the inheritance chain', ->
+      expect(@child).to.have.property 'foo', 'herp'
+
+    it 'can overwrite default attributes', ->
+      expect(@child).to.have.property 'bar', 'slurp'
+
+    it 'can inherit from grandparents', ->
+      expect(@grandChild).to.have.property 'boom', 'pow'
+      expect(@grandChild).to.have.property 'bar', 'slurp'
+      expect(@grandChild).to.have.property 'foo', 'herp'
+
+    it 'can pass arguments', ->
+      expect(@babyGrandChild).to.have.property 'foo', 'baby'
+      expect(@babyGrandChild).to.have.property 'boom', 'waaah'
+      expect(@babyGrandChild).to.have.property 'bar', 'slurp'
+
+
+  describe 'async inheriting from sync', ->
+    beforeEach (done) ->
+      syncParent = Unionized.define ->
+        @set 'foo', 'herp'
+
+      asyncChild = syncParent.define (callback) ->
+        @set 'bar', 'slurp'
+        process.nextTick -> callback()
+
+      asyncChild.build (err, @result) => done err
+
+    it 'is ok', ->
+      expect(@child).to.be.ok
+      expect(@child).to.have.property 'foo', 'herp'
+      expect(@child).to.have.property 'bar', 'slurp'
+
+
+  describe 'sync inheriting from async', ->
+    it 'is invalid', ->
+      asyncParent = Unionized.define (callback) ->
+        @set 'bar', 'slurp'
+        process.nextTick -> callback()
+
+      expect(-> asyncParent.define (->)).to.throw /cannot.*async/i
+

--- a/test/inherited_factories.spec.coffee
+++ b/test/inherited_factories.spec.coffee
@@ -54,9 +54,9 @@ describe 'inherited factories', ->
       grandChild = child.define ->
         @set 'boom', 'pow'
 
-      @child = child.build()
-      @grandChild = grandChild.build()
-      @babyGrandChild = grandChild.build(
+      @child = child.json()
+      @grandChild = grandChild.json()
+      @babyGrandChild = grandChild.json(
         foo: 'baby'
         boom: 'waaah'
       )
@@ -87,7 +87,7 @@ describe 'inherited factories', ->
         @set 'bar', 'slurp'
         process.nextTick -> callback()
 
-      asyncChild.build (err, @result) => done err
+      asyncChild.json (err, @result) => done err
 
     it 'is ok', ->
       expect(@child).to.be.ok

--- a/test/plain_factories.spec.coffee
+++ b/test/plain_factories.spec.coffee
@@ -6,10 +6,11 @@ describe 'a factory for plain objects', ->
   {factory} = {}
 
   beforeEach ->
-    factory = Unionized.define fibrous ->
+    factory = Unionized.define (callback) ->
       @set 'foo', 10
       @set 'biz.fizz', 10
       @set 'biz.faz', 10
+      process.nextTick -> callback()
 
   it 'creates an object', fibrous ->
     result = factory.sync.create()

--- a/test/synchronous_factories.spec.coffee
+++ b/test/synchronous_factories.spec.coffee
@@ -30,9 +30,9 @@ describe 'a synchronous factory', ->
 
   describe '.build', ->
     it 'is not allowed', ->
-      expect(-> factory.build()).to.throw /async/i
+      expect(-> factory.build()).to.throw /build.*sync/i
 
   describe '.create', ->
     it 'is not allowed', ->
-      expect(-> factory.create()).to.throw /async/i
+      expect(-> factory.create()).to.throw /create.*sync/i
 

--- a/test/synchronous_factories.spec.coffee
+++ b/test/synchronous_factories.spec.coffee
@@ -9,16 +9,47 @@ describe 'a synchronous factory', ->
     factory = Unionized.define ->
       @set 'name', 'apple'
 
-  it 'creates an object', fibrous ->
-    result = factory.json
-      'type': 'fruit'
-    expect(result.name).to.equal 'apple'
-    expect(result.type).to.equal 'fruit'
+  describe '.json', ->
+    describe 'with no arguments', ->
+      it 'creates an object', ->
+        result = factory.json()
+        expect(result.name).to.equal 'apple'
 
-  it 'inherits from parents', fibrous ->
-    child = factory.define ->
-      @set 'store', 'Whole Foods'
+      it 'does not accept a callback', ->
+        expect(-> factory.json(->)).to.throw()
 
-    result = child.json()
-    expect(result.store).to.equal 'Whole Foods'
-    expect(result.name).to.equal 'apple'
+    describe 'with arguments', ->
+      it 'creates an object', ->
+        result = factory.json
+          'type': 'fruit'
+        expect(result.name).to.equal 'apple'
+        expect(result.type).to.equal 'fruit'
+
+      it 'does not accept a callback', ->
+        expect(-> factory.json({type: 'fruit'}, (->))).to.throw()
+
+  describe '.build', ->
+    # (the same as `json` in this case, b/c there's no model)
+    describe 'with no arguments', ->
+      it 'creates an object', ->
+        result = factory.build()
+        expect(result.name).to.equal 'apple'
+
+      it 'does not accept a callback', ->
+        expect(-> factory.build(->)).to.throw()
+
+    describe 'with arguments', ->
+      it 'creates an object', ->
+        result = factory.build
+          'type': 'fruit'
+        expect(result.name).to.equal 'apple'
+        expect(result.type).to.equal 'fruit'
+
+      it 'does not accept a callback', ->
+        expect(-> factory.build({type: 'fruit'}, (->))).to.throw()
+
+
+  describe '.create', ->
+    it 'is not allowed', ->
+      expect(-> factory.create()).to.throw()
+

--- a/test/synchronous_factories.spec.coffee
+++ b/test/synchronous_factories.spec.coffee
@@ -16,7 +16,7 @@ describe 'a synchronous factory', ->
         expect(result.name).to.equal 'apple'
 
       it 'does not accept a callback', ->
-        expect(-> factory.json(->)).to.throw()
+        expect(-> factory.json(->)).to.throw /sync.*callback/i
 
     describe 'with arguments', ->
       it 'creates an object', ->
@@ -26,30 +26,13 @@ describe 'a synchronous factory', ->
         expect(result.type).to.equal 'fruit'
 
       it 'does not accept a callback', ->
-        expect(-> factory.json({type: 'fruit'}, (->))).to.throw()
+        expect(-> factory.json({type: 'fruit'}, (->))).to.throw /sync.*callback/i
 
   describe '.build', ->
-    # (the same as `json` in this case, b/c there's no model)
-    describe 'with no arguments', ->
-      it 'creates an object', ->
-        result = factory.build()
-        expect(result.name).to.equal 'apple'
-
-      it 'does not accept a callback', ->
-        expect(-> factory.build(->)).to.throw()
-
-    describe 'with arguments', ->
-      it 'creates an object', ->
-        result = factory.build
-          'type': 'fruit'
-        expect(result.name).to.equal 'apple'
-        expect(result.type).to.equal 'fruit'
-
-      it 'does not accept a callback', ->
-        expect(-> factory.build({type: 'fruit'}, (->))).to.throw()
-
+    it 'is not allowed', ->
+      expect(-> factory.build()).to.throw /async/i
 
   describe '.create', ->
     it 'is not allowed', ->
-      expect(-> factory.create()).to.throw()
+      expect(-> factory.create()).to.throw /async/i
 

--- a/test/throwing_factories.spec.coffee
+++ b/test/throwing_factories.spec.coffee
@@ -6,13 +6,15 @@ describe 'a factory that throws exceptions', ->
   {factory, nestingFactory, childFactory} = {}
 
   beforeEach ->
-    factory = Unionized.define fibrous ->
-      throw new Error('this is a problem factory!')
+    factory = Unionized.define (callback) ->
+      process.nextTick ->
+        callback new Error('this is a problem factory!')
 
-    nestingFactory = Unionized.define fibrous ->
-      @sync.embed 'errorFactory', factory
+    nestingFactory = Unionized.define (callback) ->
+      @sync.embed 'errorFactory', factory    # can this work??
+      callback()
 
-    childFactory = factory.define fibrous ->
+    childFactory = factory.define (callback) -> callback()
 
   it 'throws an error when JSON\'d up', fibrous ->
     expect(-> factory.sync.json()).to.throw Error

--- a/test/throwing_factories.spec.coffee
+++ b/test/throwing_factories.spec.coffee
@@ -3,6 +3,9 @@ fibrous   = require 'fibrous'
 Unionized = require '..'
 
 describe 'a factory that throws exceptions', ->
+
+  # (only 'throwing' b/c it's fibrous -- really just passing errors to callback)
+
   {factory, nestingFactory, childFactory} = {}
 
   beforeEach ->


### PR DESCRIPTION
This fixes a bunch of bugs in unionized and [unionized-mongoose](https://github.com/goodeggs/unionized-mongoose).

Hopefully the sync vs async interfaces are clearer now.
(In retrospect, we should never have introduced the sync interface, but it's there now, so...)

Several features – in particular `embedArray` – still only work with fibrous (and/or their interface with fibrous is very confusing). #6 remains open.

Will bump a major version because the interface changed a little.