### PR TITLE
[#118859023] Use existence check for json schema factory

### DIFF
--- a/src/json_schema_factory.coffee
+++ b/src/json_schema_factory.coffee
@@ -46,7 +46,7 @@ buildDefinitionFromJSONSchema = (config, propertyIsRequired) ->
       arrayInstanceDefinition = buildDefinitionFromJSONSchema(config.items, true)
       -> new EmbeddedArrayDefinition arrayInstanceDefinition
 
-    when config.default
+    when config.default?
       config.default
 
     when config.enum?.length > 0

--- a/test/json_schema.spec.coffee
+++ b/test/json_schema.spec.coffee
@@ -80,6 +80,31 @@ describe 'JSONSchema kitten tests', ->
     it 'will ignore non-required attributes', ->
       expect(@instance.description).to.be.undefined
 
+  describe 'default values', ->
+    before 'create factory', ->
+      @schema = {
+        title: "Example Test Schema"
+        type: "object"
+        required: ["shelfLife"]
+        properties: {
+          shelfLife: {
+            type: "number"
+            default: 0
+          }
+        }
+      }
+      @factory = unionized.JSONSchemaFactory @schema
+
+    beforeEach 'create instance', ->
+      @instance = @factory.create()
+
+    it 'validates', ->
+      expect(validator.validate(@instance, @schema)).to.be.ok
+
+    it 'defaults to 0', ->
+      expect(@instance.shelfLife).to.equal 0
+
+
   describe 'integers', ->
     before 'create factory', ->
       @schema = {


### PR DESCRIPTION
Adds support for falsey (fixes the zero case) default values in json schema factories.