### PR TITLE
Fix bug breaking _.times shorthand

### DIFF
--- a/src/factory.coffee
+++ b/src/factory.coffee
@@ -21,8 +21,9 @@ module.exports = class Factory extends MultiDefinition
   createAsync: (args...) ->
     if _.isFunction(args[args.length - 1])
       [args..., callback] = args
-    [overridingDefinition, factoryArguments...] = args
-    overridingDefinition = definitionFactory overridingDefinition if overridingDefinition?
+    [overridingDefinitionObject, factoryArguments...] = args
+    if _.isObject(overridingDefinitionObject)
+      overridingDefinition = definitionFactory(overridingDefinitionObject)
     factory = if overridingDefinition? then @factory(overridingDefinition) else @
     factory.buildInstanceAsync({overridingDefinition, factoryArguments})
       .then((instance) -> instance.toObjectAsync())

--- a/test/mongoose.spec.coffee
+++ b/test/mongoose.spec.coffee
@@ -180,17 +180,19 @@ describe 'mongoose kitten tests', ->
     beforeEach (done) ->
       @Model.remove (error) -> done error
 
-    beforeEach (done) ->
-      @factory.createAndSave({description: 'Big ball of fluff'}, (error) => done error)
-
-    it 'saves the kitten to the database', (done) ->
-      @Model.find (err, kittens) ->
+    it 'saves the kitten to the database', ->
+      return @factory.createAndSave({description: 'Big ball of fluff'})
+      .then =>
+        @Model.find()
+      .then (kittens) ->
         expect(kittens[0]).to.have.property 'description', 'Big ball of fluff'
-        done(err)
 
     it 'binds createAndSave to the model', ->
       Promise.all(_.times(3, @factory.createAndSave))
-      .then (kittens) -> expect(kittens).to.have.length 3
+      .then =>
+        @Model.find()
+      .then (kittens) ->
+        expect(kittens).to.have.length 3
 
   describe 'lean creation', ->
     before ->


### PR DESCRIPTION
We frequently create factories with this shorthand:
```js
_.times(3, pickInstructionFactory.createAndSave)
```

`_.times` passes a number as the first argument of the iteratee. As of 4.10.0, we did not check that this first argument (the definition override) was actually an object:
https://github.com/goodeggs/unionized/commit/488681aadeb3eb5ad7052fb0959c4a61f23e9aee#diff-f3c1823b40ea952fbc90e56ed8d171cdL22

So in the above example, `createAndSave` would return `[1,2,3]` rather than three promises.

cc @demands @jhob 