### PR TITLE
Improve fake number generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes to this project will be documented in this file.
 This project follows [SemVer 2.0.0](http://www.semver.org).
 
+## 5.0.0
+
+### Breaking
+- factories now generate negative numbers and integers
+
+### Added
+- Added support for JSON schema exclusive maximum
+
 ## 2.7.0
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "dependencies": {
     "bluebird": "^3.0.5",
-    "fake-eggs": "^1.5.0",
+    "fake-eggs": "^4.3.1",
     "goodeggs-json-schema-validator": "^4.5.2",
     "lodash": "^4.17.10"
   },
@@ -29,7 +29,6 @@
     "chai": "^2.1.2",
     "chai-as-promised": "^5.3.0",
     "coffee-script": "^1.9.2",
-    "fibrous": "~0.3.1",
     "mocha": "^2.2.5",
     "moment": "^2.10.3",
     "mongoose": "^4.0.3"

--- a/src/json_schema_factory.coffee
+++ b/src/json_schema_factory.coffee
@@ -60,9 +60,9 @@ buildDefinitionFromJSONSchema = (config, propertyIsRequired) ->
               lengthDifference = maxLength - minLength
               Math.floor(Math.random() * lengthDifference) + minLength
             if stringLength
-              return fake.randomString(stringLength)
+              return fake.string(stringLength)
             else
-              return fake.randomString()
+              return fake.string()
 
         # see https://github.com/goodeggs/goodeggs-json-schema-validator for supported formats
         when 'objectid'
@@ -85,7 +85,7 @@ buildDefinitionFromJSONSchema = (config, propertyIsRequired) ->
         min = config.minimum ? 0
         min += 1 if config.exclusiveMinimum
         max = config.maximum ? 100
-        fake.integerInRange(min, max)
+        fake.integer(min, max)
 
     when type is 'number'
       ->
@@ -96,4 +96,4 @@ buildDefinitionFromJSONSchema = (config, propertyIsRequired) ->
         min = Math.ceil(min * magnitude)
         min = min + 1 if config.exclusiveMinimum
         max = Math.floor(max * magnitude)
-        fake.integerInRange(min, max) / magnitude
+        fake.integer(min, max) / magnitude

--- a/src/json_schema_factory.coffee
+++ b/src/json_schema_factory.coffee
@@ -82,18 +82,16 @@ buildDefinitionFromJSONSchema = (config, propertyIsRequired) ->
 
     when type is 'integer'
       ->
-        min = config.minimum ? 0
+        min = config.minimum ? -100
         min += 1 if config.exclusiveMinimum
         max = config.maximum ? 100
+        max -= 1 if config.exclusiveMaximum
         fake.integer(min, max)
 
     when type is 'number'
       ->
-        min = config.minimum ? 0
-        max = config.maximum ? 100.0
-        SIG_DIGITS = 2
-        magnitude = Math.pow 10, SIG_DIGITS
-        min = Math.ceil(min * magnitude)
-        min = min + 1 if config.exclusiveMinimum
-        max = Math.floor(max * magnitude)
-        fake.integer(min, max) / magnitude
+        min = config.minimum ? -100
+        min += 0.001 if config.exclusiveMinimum
+        max = config.maximum ? 100
+        max -= 0.001 if config.exclusiveMaximum
+        fake.number(min, max)

--- a/src/mongoose_factory.coffee
+++ b/src/mongoose_factory.coffee
@@ -40,9 +40,9 @@ buildDefinitionFromSchemaType = (schemaType, mongoose, {ignoreRequired} = {}) ->
 
     when schemaType instanceof mongoose.SchemaTypes.Number
       ->
-        min = schemaType.options.min ? 0
-        max = schemaType.options.max ? 100.0
-        return fake.integer(min, max)
+        min = schemaType.options.min ? -100
+        max = schemaType.options.max ? 100
+        return fake.number(min, max)
 
 buildDefinitionObjectFromSchema = (schema, mongoose) ->
   definitionObject = {}

--- a/src/mongoose_factory.coffee
+++ b/src/mongoose_factory.coffee
@@ -20,7 +20,7 @@ buildDefinitionFromSchemaType = (schemaType, mongoose, {ignoreRequired} = {}) ->
       schemaType.defaultValue
 
     when schemaType.enumValues?.length > 0
-      -> fake.randomArrayElement(schemaType.enumValues)
+      -> fake.sample(schemaType.enumValues)
 
     when schemaType instanceof mongoose.SchemaTypes.Array
       arrayInstanceDefinition = buildDefinitionFromSchemaType(schemaType.caster, mongoose, ignoreRequired: false)
@@ -30,19 +30,19 @@ buildDefinitionFromSchemaType = (schemaType, mongoose, {ignoreRequired} = {}) ->
       -> new mongoose.Types.ObjectId()
 
     when schemaType instanceof mongoose.SchemaTypes.Boolean
-      -> fake.randomArrayElement([true, false])
+      -> fake.sample([true, false])
 
     when schemaType instanceof mongoose.SchemaTypes.Date
       fake.date
 
     when schemaType instanceof mongoose.SchemaTypes.String
-      fake.randomString
+      fake.string
 
     when schemaType instanceof mongoose.SchemaTypes.Number
       ->
         min = schemaType.options.min ? 0
         max = schemaType.options.max ? 100.0
-        return fake.integerInRange(min, max)
+        return fake.integer(min, max)
 
 buildDefinitionObjectFromSchema = (schema, mongoose) ->
   definitionObject = {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,11 +94,11 @@ escape-string-regexp@1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz#4dbc2fe674e71949caf3fb2695ce7f2dc1d9a8d1"
 
-fake-eggs@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.npmjs.org/fake-eggs/-/fake-eggs-1.5.0.tgz#de96f7301b190fadea5651ae82570efd1bc4c771"
+fake-eggs@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.npmjs.org/fake-eggs/-/fake-eggs-4.3.1.tgz#3a651ce53b40e81c718794de8a4bc309e9ea7860"
   dependencies:
-    lodash "^4.0.1"
+    lodash "4.17.5"
 
 falafel@~1.2.0:
   version "1.2.0"
@@ -108,16 +108,6 @@ falafel@~1.2.0:
     foreach "^2.0.5"
     isarray "0.0.1"
     object-keys "^1.0.6"
-
-fibers@>=0.6.7:
-  version "1.0.15"
-  resolved "https://registry.npmjs.org/fibers/-/fibers-1.0.15.tgz#22f039c8f18b856190fbbe4decf056154c1eae9c"
-
-fibrous@~0.3.1:
-  version "0.3.3"
-  resolved "https://registry.npmjs.org/fibrous/-/fibrous-0.3.3.tgz#8abbf6c8047969b3422e42f2a511a8ed8ebe79f2"
-  dependencies:
-    fibers ">=0.6.7"
 
 foreach@^2.0.5:
   version "2.0.5"
@@ -167,7 +157,11 @@ kareem@1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/kareem/-/kareem-1.2.1.tgz#acdb8c8119845834abbfa58ade1cf9dea63dc752"
 
-lodash@^4.0.1, lodash@^4.14.0, lodash@^4.17.10:
+lodash@4.17.5:
+  version "4.17.5"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+
+lodash@^4.14.0, lodash@^4.17.10:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 


### PR DESCRIPTION
- use latest `fake-eggs`
- generate negative numbers and integers
- add support for JSON schema `exclusiveMaximum`
- `exclusiveMinimum`/`exclusiveMaximum` for "number" includes fractional
- use `fake.number()` instead of hack with `fake.integer()`