### PR TITLE
drop support for node 4, 6; add for 8, 10, 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: node_js
 cache: yarn
 node_js:
-  - "4"
-  - "6"
+  - "12"
+  - "10"
+  - "8"
 services:
   - mongodb
 script: yarn run ci


### PR DESCRIPTION
Node 4 and 6 are no longer in maintenance, so stop testing against them. Start testing against Node 8, 10, and 12.