### PR TITLE
feat: JSONSchemaFactory supports minItems, maxItems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,22 @@
 All notable changes to this project will be documented in this file.
 This project follows [SemVer 2.0.0](http://www.semver.org).
 
+## 6.1.0
+
+- Added support for `minItems` and `maxItems` on array properties in `JSONSchemaFactory`
+  - This is not a breaking change; however, previously array properties by default were always
+    generated with exactly two elements. This was not documented, so it is not considered a breaking
+    change. However, you may have tests that were accidentally relying on this behavior.
 
 ## 6.0.0
 
 ### Breaking
-- dropped support for Node 4 and Node 6
+- Dropped support for Node 4 and Node 6
 
 ## 5.0.0
 
 ### Breaking
-- factories now generate negative numbers and integers
+- Factories now generate negative numbers and integers
 
 ### Added
 - Added support for JSON schema exclusive maximum

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "unionized",
   "main": "./lib/index.js",
-  "version": "6.0.0",
+  "version": "6.1.0-0",
   "scripts": {
     "build": "coffee --bare --output lib/ --compile src/*.coffee",
     "pretest": "yarn run build",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "unionized",
   "main": "./lib/index.js",
-  "version": "6.1.0-0",
+  "version": "6.1.0",
   "scripts": {
     "build": "coffee --bare --output lib/ --compile src/*.coffee",
     "pretest": "yarn run build",

--- a/src/json_schema_factory.coffee
+++ b/src/json_schema_factory.coffee
@@ -38,7 +38,7 @@ buildDefinitionFromJSONSchema = (config, propertyIsRequired) ->
 
     when type is 'array'
       arrayInstanceDefinition = buildDefinitionFromJSONSchema(config.items, true)
-      -> new EmbeddedArrayDefinition arrayInstanceDefinition
+      -> new EmbeddedArrayDefinition arrayInstanceDefinition, generateArrayLength(config)
 
     when config.default?
       config.default
@@ -95,3 +95,13 @@ buildDefinitionFromJSONSchema = (config, propertyIsRequired) ->
         max = config.maximum ? 100
         max -= 0.001 if config.exclusiveMaximum
         fake.number(min, max)
+
+generateArrayLength = (config) ->
+  # Ensure we generate valid defaults in all cases:
+  # - no minItems, no maxItems: 0 to 100
+  # - minItems only: minItems to (minItems+100)
+  # - maxItems only: 0 to maxItems
+  # - minItems, maxItems: use them
+  minItems = config.minItems ? 0
+  maxItems = config.maxItems ? minItems + 100
+  return Math.floor(Math.random() * (maxItems - minItems)) + minItems

--- a/test/json_schema.spec.coffee
+++ b/test/json_schema.spec.coffee
@@ -1,7 +1,9 @@
 expect = require('chai').expect
+fake = require('fake-eggs')
 moment = require 'moment'
-unionized = require '../src'
 validator = require 'goodeggs-json-schema-validator'
+
+unionized = require '../src'
 
 describe 'JSONSchema kitten tests', ->
   beforeEach 'clear instance', ->
@@ -102,7 +104,6 @@ describe 'JSONSchema kitten tests', ->
 
     it 'defaults to 0', ->
       expect(@instance.shelfLife).to.equal 0
-
 
   describe 'integers', ->
     before 'create factory', ->
@@ -213,6 +214,68 @@ describe 'JSONSchema kitten tests', ->
       expect(@instance.paws[0]).to.be.a 'object'
       expect(@instance.paws[0]).to.have.property 'nickname'
       expect(@instance.paws[0].clawCount).not.to.be.ok
+
+    it 'generates a number of array elements greater than or equal to given `minItems` if provided', ->
+      minItems = fake.integer(0)
+      schema = {
+        # TODO(serhalp) unionized does not support top-level arrays - simplify this when it does
+        type: 'object',
+        required: ['arr'],
+        properties: {
+          arr: {
+            type: 'array'
+            items: {
+              type: 'integer'
+            }
+            minItems
+          }
+        }
+      }
+      factory = unionized.JSONSchemaFactory(schema)
+
+      expect(factory.create().arr).to.have.length.of.at.least(minItems)
+
+    it 'generates a number of array elements less than or equal to given `maxItems` if provided', ->
+      maxItems = fake.integer(0)
+      schema = {
+        # TODO(serhalp) unionized does not support top-level arrays - simplify this when it does
+        type: 'object',
+        required: ['arr'],
+        properties: {
+          arr: {
+            type: 'array'
+            items: {
+              type: 'integer'
+            }
+            maxItems
+          }
+        }
+      }
+      factory = unionized.JSONSchemaFactory(schema)
+
+      expect(factory.create().arr).to.have.length.at.most(maxItems)
+
+    it 'generates a number of array elements between `minItems` and `maxItems` inclusively if provided', ->
+      minItems = fake.integer(0)
+      maxItems = fake.integer(minItems)
+      schema = {
+        # TODO(serhalp) unionized does not support top-level arrays - simplify this when it does
+        type: 'object',
+        required: ['arr'],
+        properties: {
+          arr: {
+            type: 'array'
+            items: {
+              type: 'integer'
+            }
+            minItems
+            maxItems
+          }
+        }
+      }
+      factory = unionized.JSONSchemaFactory(schema)
+
+      expect(factory.create().arr).to.have.length.within(minItems, maxItems)
 
   describe 'deeply-nested attributes', ->
     before 'create kitten', ->


### PR DESCRIPTION
Previously, it was possible for JSONSchemaFactory to generate invalid objects given a JSON Schema with an array property with specified `minItems` and/or `maxItems`. Now these generated documents will always be valid.

This is a backwards compatible change. However, previously there was a hardcoded default that was always generating exactly two elements in array properties created via JSONSchemaFactory. Because this was never documented behavior, this will not be considered a breaking change.