### PR TITLE
feat(JSONSchemaFactory): add support for "decimal" format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 This project follows [SemVer 2.0.0](http://www.semver.org).
+
+## 6.3.0
+
+- Added support for `format: 'decimal'` in `JSONSchemaFactory`
+
+## 6.2.1
+
+- Fix rare edge case that would generate out-of-range number
+- Restrict default range of `format: 'date'` and `format: 'date-time'` in `JSONSchemaFactory` to a
+  smaller, more reasonable range (approx. 1001-01-01 to 9999-01-01).
+- Upgrade internal dependencies
 
 ## 6.1.0
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "unionized",
   "main": "./lib/index.js",
-  "version": "6.2.1",
+  "version": "6.3.0",
   "scripts": {
     "build": "coffee --bare --output lib/ --compile src/*.coffee",
     "pretest": "yarn run build",

--- a/src/json_schema_factory.coffee
+++ b/src/json_schema_factory.coffee
@@ -84,6 +84,9 @@ buildDefinitionFromJSONSchema = (config, propertyIsRequired) ->
         when 'uri'
           fake.uri
 
+        when 'decimal'
+          -> fake.number().toString()
+
     when type is 'integer'
       ->
         minInclusive = config.minimum ? -100

--- a/test/json_schema.spec.coffee
+++ b/test/json_schema.spec.coffee
@@ -14,7 +14,7 @@ describe 'JSONSchema kitten tests', ->
       @kittenSchema = {
         title: "Example Test Schema"
         type: "object"
-        required: ["_id", "name", "tag", "bornAt", "bornDay", "contact", "website", "cutenessPercentile", "personality", "eyeColor", "isHunter"]
+        required: ["_id", "name", "tag", "bornAt", "bornDay", "contact", "website", "formattedPrice", "cutenessPercentile", "personality", "eyeColor", "isHunter"]
         properties: {
           _id: { type: "string", format: "objectid" }
           tag: { type: "string", minLength: 5, maxLength: 5 },
@@ -23,6 +23,7 @@ describe 'JSONSchema kitten tests', ->
           bornDay: { type: "string", format: "date" },
           contact: { type: "string", format: "email" },
           website: { type: "string", format: "uri" },
+          formattedPrice: { type: "string", format: "decimal" },
           cutenessPercentile: { type: "integer" },
           personality: { type: "string", enum: ["friendly", "fierce", "antisocial", "changeable"] },
           eyeColor: { type: "string", default: "yellow" },
@@ -60,6 +61,12 @@ describe 'JSONSchema kitten tests', ->
 
     it 'can generate string with format url', ->
       expect(@instance.website).to.contain 'http'
+
+    it 'can generate string with format "decimal"', ->
+      expect(@instance.formattedPrice).to.be.a('string')
+      expect(
+        Number.isNaN(Number(@instance.formattedPrice))
+      ).to.be.false
 
     it 'can generate a number', ->
       expect(@instance.cutenessPercentile).to.be.a 'number'


### PR DESCRIPTION
This already supports custom, somewhat Good Eggs-specific JSON Schema formats, and has no affordance to register custom formats at runtime, so this seems OK.

This is sort of a deprecated module anyway, so this seems doubly OK, and this solves a problem for us right now!