### PR TITLE
fix(JSONSchemaFactory): respect underlying number range for "decimal"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "unionized",
   "main": "./lib/index.js",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "scripts": {
     "build": "coffee --bare --output lib/ --compile src/*.coffee",
     "pretest": "yarn run build",

--- a/src/json_schema_factory.coffee
+++ b/src/json_schema_factory.coffee
@@ -85,7 +85,12 @@ buildDefinitionFromJSONSchema = (config, propertyIsRequired) ->
           fake.uri
 
         when 'decimal'
-          -> fake.number().toString()
+          # Reuse existing `number` generation logic (respecting min/max, etc.) and then just
+          # convert it to a string.
+          -> buildDefinitionFromJSONSchema(
+            Object.assign({}, config, {type: 'number'}),
+            propertyIsRequired,
+          )().toString()
 
     when type is 'integer'
       ->

--- a/test/json_schema.spec.coffee
+++ b/test/json_schema.spec.coffee
@@ -225,6 +225,28 @@ describe 'JSONSchema kitten tests', ->
         instance = factory.create()
         expect(instance.frequency).not.to.equal(1)
 
+  describe 'string format "decimal"', ->
+    # Just test `minimum` to verify that we are correctly deferring to underlying `number` logic.
+    it 'respects `maximum`', ->
+      schema = {
+        type: "object"
+        required: ["formattedPrice"]
+        properties: {
+          formattedPrice: {
+            type: "string"
+            format: "decimal"
+            maximum: 5
+          }
+        }
+      }
+      factory = unionized.JSONSchemaFactory(schema)
+      for time in [0...100]
+        instance = factory.create()
+        expect(instance.formattedPrice).to.be.a('string')
+        price = Number(instance.formattedPrice)
+        expect(Number.isNaN(price)).to.be.false
+        expect(price).to.be.lessThan(5)
+
   describe 'instantiating with unknown field', ->
     before 'create kitten', ->
       @kittenSchema = {


### PR DESCRIPTION
In https://github.com/goodeggs/unionized/pull/130 I implemented support for a new "decimal" string format in `JSONSchemaFactory`. However, this isn't respecting the number properties like `minimum`, `maximum`, `exclusiveMinimum`, and `exclusiveMaximum`. This was kind of the whole point and it isn't viable for our use cases without it, since it otherwise generates data that doesn't validate against its own schema.

This fixes the issue by reusing the `number` data generation logic and then just calling `toString()` on the result. Simple!